### PR TITLE
igvm: Create a new flag to specify the architecture

### DIFF
--- a/src/igvm/igvmbase.py
+++ b/src/igvm/igvmbase.py
@@ -17,6 +17,7 @@ class IGVMBaseGenerator(object):
         sign_key = kwargs["sign_key"] if "sign_key" in kwargs else None
         pem = sign_key.read() if sign_key else None
         boot_mode = kwargs["boot_mode"]
+        self.arch = kwargs["arch"]
         self.state: IGVMFile = IGVMFile(boot_mode=boot_mode,
                                         config_path=config,  pem=pem)
         self.cpuid_page: int = 0

--- a/src/igvm/igvmbzimage.py
+++ b/src/igvm/igvmbzimage.py
@@ -8,7 +8,7 @@ from igvm.acpi import ACPI, ACPI_RSDP_ADDR
 from igvm.bootcstruct import *
 from igvm.igvmbase import IGVMBaseGenerator
 from igvm.igvmfile import PGSIZE, ALIGN
-from igvm.vmstate import ARCH
+from igvm.vmstate import ARCH, Arch
 
 boot_params = struct_boot_params
 setup_header = struct_setup_header
@@ -259,7 +259,8 @@ class IGVMLinuxGenerator(IGVMBaseGenerator):
         self.state.vmsa.rip = kernel_entry
         self.state.vmsa.rsi = boot_params_addr
         self.state.vmsa.rsp = boot_stack_addr + PGSIZE
-        self.state.vmsa.rflags = 2
+        if self.arch == Arch.Intel:
+            self.state.vmsa.rflags = 2
 
 
 class IGVMLinux2Generator(IGVMLinuxGenerator):

--- a/src/igvm/igvmelf.py
+++ b/src/igvm/igvmelf.py
@@ -11,7 +11,7 @@ from igvm.bootcstruct import *
 from igvm.acpi import ACPI, ACPI_RSDP_ADDR
 from igvm.igvmbase import IGVMBaseGenerator
 from igvm.igvmfile import PGSIZE, ALIGN
-from igvm.vmstate import ARCH
+from igvm.vmstate import ARCH, Arch
 boot_params = struct_boot_params
 setup_header = struct_setup_header
 
@@ -24,6 +24,7 @@ class IGVMELFGenerator(IGVMBaseGenerator):
         IGVMBaseGenerator.__init__(self, **kwargs)
         self.extra_validated_ram: List = []
         self._start = kwargs["start_addr"]
+        self.arch = kwargs["arch"]
 
         acpi_dir = kwargs["acpi_dir"] if "acpi_dir" in kwargs else None
         self.acpidata: ACPI = ACPI(acpi_dir)
@@ -120,7 +121,8 @@ class IGVMELFGenerator(IGVMBaseGenerator):
         vmpl2_kernel_addr = 0x3d00000
         self.state.vmsa.rip = kernel_entry
         self.state.vmsa.rsi = monitor_params_addr
-        self.state.vmsa.rflags = 2
+        if self.arch == Arch.Intel:
+            self.state.vmsa.rflags = 2
         # Load VMPL2 kernel
         self.load_vmpl2_kernel(vmpl2_kernel_addr)
 

--- a/src/igvm/igvmgen.py
+++ b/src/igvm/igvmgen.py
@@ -11,7 +11,7 @@ from igvm.bootcstruct import *
 from igvm.igvmbzimage import IGVMLinuxGenerator, IGVMLinux2Generator
 from igvm.igvmelf import IGVMELFGenerator
 from igvm.igvmfile import IGVMFile
-from igvm.vmstate import ARCH
+from igvm.vmstate import ARCH, Arch
 
 
 class INFORM(Enum):
@@ -46,6 +46,8 @@ def main(argv=None):
         metavar='igvmfile.bin', help='igvmfile for inspection')
     parser.add_argument(
         '-inform', type=INFORM, default=INFORM.bzImage, help='igvm input format', required=False)
+    parser.add_argument(
+        '-arch', type=Arch, default=Arch.Intel, help='hardware architecture', required=False)
     parser.add_argument(
         '-o', type=argparse.FileType('wb'),
         metavar='igvmfile.bin', help='igvmfile to output')

--- a/src/igvm/vmstate.py
+++ b/src/igvm/vmstate.py
@@ -35,6 +35,11 @@ class ARCH(Enum):
     X64 = 'x64'
 
 
+class Arch(Enum):
+    Intel = "Intel"
+    AMD = "AMD"
+
+
 class SegAttr(Structure):
     _fields_ = [('type', c_uint16, 4),
                 ('s', c_uint16, 1),

--- a/src/test/test_igvm.py
+++ b/src/test/test_igvm.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from igvm.vmstate import ARCH
+from igvm.vmstate import ARCH, Arch
 import tracemalloc
 
 
@@ -70,6 +70,7 @@ class IgvmGenTest(unittest.TestCase):
                 "vtl": 2,
                 "acpi_dir": TEST_ACPI,
                 "boot_mode": ARCH.X86,
+                "arch": Arch.Intel,
                 "sign_key": None,
                 "kernel": infile,
             }
@@ -89,6 +90,7 @@ class IgvmGenTest(unittest.TestCase):
                 "symbol_elf": "",
                 "vtl": 2,
                 "boot_mode": ARCH.X64,
+                "arch": Arch.Intel,
                 "sign_key": None,
                 "kernel": infile,
             }
@@ -108,6 +110,7 @@ class IgvmGenTest(unittest.TestCase):
                 "symbol_elf": "",
                 "vtl": 2,
                 "boot_mode": ARCH.X86,
+                "arch": Arch.Intel,
                 "sign_key": None,
                 "kernel": infile,
                 "shared_payload": MockedFileObj(b'12345678')
@@ -129,6 +132,7 @@ class IgvmGenTest(unittest.TestCase):
                 "vtl": 2,
                 "acpi_dir": TEST_ACPI,
                 "boot_mode": ARCH.X86,
+                "arch": Arch.Intel,
                 "sign_key": None,
                 "kernel": infile,
             }
@@ -149,6 +153,7 @@ class IgvmGenTest(unittest.TestCase):
                 "vtl": 2,
                 "acpi_dir": None,
                 "boot_mode": ARCH.X86,
+                "arch": Arch.Intel,
                 "sign_key": None,
                 "kernel": infile,
                 "start_addr": 0x1a00000


### PR DESCRIPTION
This way we can create customization for Intel vs AMD architecture.