### PR TITLE
Properly set default for -svn flag

### DIFF
--- a/src/igvm/igvmgen.py
+++ b/src/igvm/igvmgen.py
@@ -167,7 +167,7 @@ def main(argv=None):
         '-svn',
         type=str,
         help="VMGS file SVN",
-        metavar='0'
+        default='0'
     )
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
This is a follow up to #32 to properly set the default guest SVN value to `'0'` when the `-svn` flag isn't set. Currently, the JSON field is set to `None` in that case.