### PR TITLE
.gitignore: Ignore new folders for CLH ACPI tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-igvm/acpi/acpi-test/*.aml
-igvm/acpi/acpi-test-aml
-igvm/acpi/acpi-test-new
+src/igvm/acpi/acpi-test/*.aml
+src/igvm/acpi/acpi-test-aml
+src/igvm/acpi/acpi-test-new
+src/igvm/acpi/acpi-clh/*-new
+src/igvm/acpi/acpi-clh/*/*.aml
 .vscode


### PR DESCRIPTION
While at it also fix the other entries in gitignore which should be updated when changed the structure of source directory.