### PR TITLE
.gitignore: Ignore the generated AML files for CLH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,6 @@ dmypy.json
 src/igvm/acpi/acpi-test/*.aml
 src/igvm/acpi/acpi-test-aml
 src/igvm/acpi/acpi-test-new
-src/igvm/acpi/acpi-clh/*-new
-src/igvm/acpi/acpi-clh/*/*.aml
+src/igvm/acpi/acpi-clh-new
+src/igvm/acpi/acpi-clh/*.aml
 .vscode


### PR DESCRIPTION
This was a leftover from previous effort to unify the IGVM files for Cloud Hypervisor.