### PR TITLE
acpi: update dsl files in tempdir

### DIFF
--- a/src/igvm/acpi.py
+++ b/src/igvm/acpi.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pickle
 import subprocess
+import tempfile
 import zlib
 from typing import Dict, List
 
@@ -108,7 +109,7 @@ class ACPIUpdate:
     def update_dsl(self):
         if len(self.updates) + len(self.appends) == 0:
             return
-        newdir = os.path.dirname(self.dslpath) + "-new"
+        newdir = tempfile.mkdtemp("-new")
         if not os.path.exists(newdir):
             os.mkdir(newdir)
         newdsl = os.path.join(newdir, os.path.basename(self.dslpath))


### PR DESCRIPTION
While packaging this tool in nixpkgs, I wanted to place the acpi data (dsl files) in a readonly location.
This requires the use of a different, writable location when performing updates.