### PR TITLE
Add deterministic id block signature mode

### DIFF
--- a/src/igvm/igvmbase.py
+++ b/src/igvm/igvmbase.py
@@ -18,12 +18,14 @@ class IGVMBaseGenerator(object):
         # Init IGVMFile state
         config = kwargs["config"] if "config" in kwargs else None
         sign_key = kwargs["sign_key"] if "sign_key" in kwargs else None
+        sign_deterministic = kwargs["sign_deterministic"] if "sign_deterministic" in kwargs else False
         pem = sign_key.read() if sign_key else None
         boot_mode = kwargs["boot_mode"]
         self.arch = kwargs["arch"]
         self.state: IGVMFile = IGVMFile(boot_mode=boot_mode,
                                         config_path=config,
                                         pem=pem,
+                                        sign_deterministic=sign_deterministic,
                                         encrypted_page=kwargs["encrypted_page"],
                                         svme=kwargs["svme"])
         self.cpuid_page: int = 0

--- a/src/igvm/igvmgen.py
+++ b/src/igvm/igvmgen.py
@@ -120,6 +120,12 @@ def main(argv=None):
         required=False
     )
     parser.add_argument(
+        '-sign_deterministic',
+        type=str2bool,
+        default=False,
+        help='Enables deterministic id block signing using RFC6979 deterministic ECDSA instead of using a random k value'
+    )
+    parser.add_argument(
         '-acpi_dir',
         type=str,
         help='ACPI folder',


### PR DESCRIPTION
With this change, igvm files can be created deterministically (when using the same signing key).