### PR TITLE
igvm: Remove unused imports

### DIFF
--- a/src/igvm/igvmgen.py
+++ b/src/igvm/igvmgen.py
@@ -6,7 +6,6 @@ import sys
 import json
 import logging
 
-from distutils.log import INFO
 from enum import Enum
 from frozendict import frozendict
 


### PR DESCRIPTION
distutils is not being used currently anywhere in the codebase. Thus, remove it.