### PR TITLE
setup.py: Add missing dependency

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -24,5 +24,6 @@ setup(
         "pytest",
         "cached_property",
         "frozendict",
+        "setuptools",
     ]
 )


### PR DESCRIPTION
Without this I got the following error while running inside a virtual environment with python 3.12:

ModuleNotFoundError: No module named 'pkg_resources'