### PR TITLE
igvm: Add CPUID 0xD sub-functions 11 and 12 for CET xstate

### DIFF
--- a/src/igvm/igvmfile.py
+++ b/src/igvm/igvmfile.py
@@ -499,6 +499,8 @@ class IGVMFile(VMState):
                         (CpuIdFunctionExtendedStateEnumeration, 6),
                         (CpuIdFunctionExtendedStateEnumeration, 7),
                         (CpuIdFunctionExtendedStateEnumeration, 8),
+                        (CpuIdFunctionExtendedStateEnumeration, 11),
+                        (CpuIdFunctionExtendedStateEnumeration, 12),
                         (CpuIdFunctionExtendedBrandingString1, 0),
                         (CpuIdFunctionExtendedBrandingString2, 0),
                         (CpuIdFunctionExtendedBrandingString3, 0),


### PR DESCRIPTION
The SNP CPUID table template only includes CPUID 0xD (Extended State Enumeration) sub-functions 0 through 8. On hosts that support CET (Control-flow Enforcement Technology), CPUID 0xD:1 advertises CET_U (bit 11) and CET_S (bit 12) in the XSS supervisor state mask (ECX).

When the guest kernel processes CPUID 0xD:1 and finds CET xstate bits enabled, it calls snp_cpuid_calc_xsave_size() to compute the total xsave area size by iterating over all enabled xfeature sub-functions. Since sub-functions 11 and 12 are missing from the SNP CPUID table, the lookup fails with xfeatures_found != xfeatures_en, returning 0. This causes the kernel to call sev_es_terminate(), which sends GHCB_MSR_TERM_REQ (VMGEXIT 0x100) and crashes the VM.

Add sub-functions 11 (CET_U) and 12 (CET_S) to the CPUID 0xD entries in the SNP CPUID table template. The PSP firmware populates the actual EAX/EBX/ECX/EDX values at launch time from hardware. On hosts without CET support, these entries are harmlessly zeroed out by the PSP.

Testing:

  Reproducer (on Azure  with CET, /dev/mshv):

  igvmgen -kernel bzImage \
    -append "console=ttyS0 root=/dev/vda1 rw" \
    -boot_mode x64 -vtl 0 -svme 1 -encrypted_page 1 \
    -pvalidate_opt 1 -o output.bin

  cloud-hypervisor --cpus boot=1,nested=off --memory size=512M \
    --disk path=osdisk.img path=cloudinit \
    --igvm output.bin --platform sev_snp=on -v

  Before fix (with Cloud Hypervisor GHCB CPUID handler patched):

    Guest kernel panics during xsave size computation:
    x86/fpu: misordered xstate at 576
    sev_es_terminate() -> VMGEXIT 0x100 (GHCB_MSR_TERM_REQ)

  After fix: VM boots successfully to login prompt.